### PR TITLE
Upgrade to veewee/xml v4.8

### DIFF
--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ubuntu-latest]
-                php-versions: ['8.3', '8.4', '8.5']
+                php-versions: ['8.4', '8.5']
                 composer-options: ['--ignore-platform-req=php+']
             fail-fast: false
         name: PHP ${{ matrix.php-versions }} @ ${{ matrix.operating-system }}

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
         }
     ],
     "require": {
-        "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
+        "php": "~8.4.0 || ~8.5.0",
         "ext-dom": "*",
         "phpunit/phpunit": "~12.3",
         "php-soap/engine": "^2.16",
         "php-soap/xml": "^1.9",
         "php-vcr/php-vcr": "^1.6.0",
-        "veewee/xml": "^3.0"
+        "veewee/xml": "^4.8"
     },
     "require-dev": {
         "php-cs-fixer/shim": "~3.88"

--- a/src/AbstractIntegrationTest.php
+++ b/src/AbstractIntegrationTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Soap\EngineIntegrationTests;
 
-use DOMElement;
+use Dom\Element;
 use PHPUnit\Framework\TestCase;
 use Soap\Xml\Locator\SoapBodyLocator;
 use Soap\Xml\Xpath\EnvelopePreset;
@@ -34,7 +34,7 @@ abstract class AbstractIntegrationTest extends TestCase
         return $results;
     }
 
-    protected function runSingleElementXpathOnBody(Document $xml, string $xpath): DOMElement
+    protected function runSingleElementXpathOnBody(Document $xml, string $xpath): Element
     {
         $body = $xml->locate(new SoapBodyLocator());
 


### PR DESCRIPTION
## Summary
- Bump minimum PHP version to 8.4 (drop 8.3)
- Upgrade `veewee/xml` from `^3.0` to `^4.8`
- Replace `DOMElement` with `Dom\Element` (PHP 8.4 spec-compliant DOM API)
- Remove PHP 8.3 from CI matrix

## Test plan
- [ ] CI passes on PHP 8.4 and 8.5
- [ ] php-cs-fixer passes (verified locally)